### PR TITLE
Use TaskGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 [Unreleased]: https://github.com/getindata/dbt-airflow-manifest-parser/compare/0.12.0...HEAD
 
+-   Allow usage of TaskGroup when `use_task_group` flag is set to `True`
+
 [0.12.0]: https://github.com/getindata/dbt-airflow-manifest-parser/compare/0.11.0...0.12.0
 
 [0.11.0]: https://github.com/getindata/dbt-airflow-manifest-parser/compare/0.10.0...0.11.0

--- a/dbt_airflow_manifest_parser/airflow_dag_factory.py
+++ b/dbt_airflow_manifest_parser/airflow_dag_factory.py
@@ -40,7 +40,7 @@ class AirflowDagFactory:
         start = self._create_starting_task(config)
         end = DummyOperator(task_id="end")
         tasks = self._builder.parse_manifest_into_tasks(
-            self._manifest_file_path(config)
+            self._manifest_file_path(config), config.get("use_task_group") or False
         )
         for starting_task in tasks.get_starting_tasks():
             start >> starting_task.run_airflow_task

--- a/dbt_airflow_manifest_parser/tasks.py
+++ b/dbt_airflow_manifest_parser/tasks.py
@@ -1,28 +1,44 @@
-from typing import List
+from typing import Dict, List
 
 from airflow.models.baseoperator import BaseOperator
 
 
 class ModelExecutionTask:
-    def __init__(self, run_airflow_task: BaseOperator, test_airflow_task: BaseOperator):
+    def __init__(
+        self,
+        run_airflow_task: BaseOperator,
+        test_airflow_task: BaseOperator,
+        task_group=None,
+    ):
         self.run_airflow_task = run_airflow_task
         self.test_airflow_task = test_airflow_task
+        self.task_group = task_group
 
-    # todo only for airflow 2.x
-    def to_task_group(self):
-        return None
+    def __repr__(self):
+        return repr(self.task_group) or repr(
+            [self.run_airflow_task, self.test_airflow_task]
+        )
+
+    def get_start_task(self):
+        return self.task_group or self.run_airflow_task
+
+    def get_end_task(self):
+        return self.task_group or self.test_airflow_task
 
 
 class ModelExecutionTasks:
     def __init__(
         self,
-        tasks: List[ModelExecutionTask],
+        tasks: Dict[str, ModelExecutionTask],
         starting_task_names: List[str],
         ending_task_names: List[str],
     ):
         self._tasks = tasks
         self._starting_task_names = starting_task_names
         self._ending_task_names = ending_task_names
+
+    def __repr__(self):
+        return f"ModelExecutionTasks(\n {self._tasks} \n)"
 
     def get_task(self, node_name) -> ModelExecutionTask:
         return self._tasks[node_name]

--- a/tests/config/base/airflow.yml
+++ b/tests/config/base/airflow.yml
@@ -18,3 +18,4 @@ dag:
 
 seed_task: True
 manifest_file_name: ../tests/manifest.json
+use_task_group: True

--- a/tests/config/no_task_group/airflow.yml
+++ b/tests/config/no_task_group/airflow.yml
@@ -1,0 +1,2 @@
+use_task_group: False
+manifest_file_name: ../tests/manifest_task_group_tests.json

--- a/tests/config/task_group/airflow.yml
+++ b/tests/config/task_group/airflow.yml
@@ -1,0 +1,2 @@
+use_task_group: True
+manifest_file_name: ../tests/manifest_task_group_tests.json

--- a/tests/manifest_task_group_tests.json
+++ b/tests/manifest_task_group_tests.json
@@ -1,0 +1,31 @@
+{
+  "nodes": {
+    "model.dbt_test.model1": {
+      "depends_on": {
+        "nodes": []
+      }
+    },
+    "model.dbt_test.model2": {
+      "depends_on": {
+        "nodes": [
+          "model.dbt_test.model1"
+        ]
+      }
+    },
+    "model.dbt_test.model3": {
+      "depends_on": {
+        "nodes": [
+          "model.dbt_test.model1"
+        ]
+      }
+    },
+    "model.dbt_test.model4": {
+      "depends_on": {
+        "nodes": [
+          "model.dbt_test.model2",
+          "model.dbt_test.model3"
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_config_propagation.py
+++ b/tests/test_config_propagation.py
@@ -1,6 +1,11 @@
 from airflow.kubernetes.secret import Secret
 
-from .utils import builder_factory, IS_FIRST_AIRFLOW_VERSION, manifest_file_with_models, test_dag
+from .utils import (
+    IS_FIRST_AIRFLOW_VERSION,
+    builder_factory,
+    manifest_file_with_models,
+    test_dag,
+)
 
 
 def test_configuration():

--- a/tests/test_config_propagation.py
+++ b/tests/test_config_propagation.py
@@ -1,6 +1,6 @@
 from airflow.kubernetes.secret import Secret
 
-from .utils import builder_factory, manifest_file_with_models, test_dag
+from .utils import builder_factory, IS_FIRST_AIRFLOW_VERSION, manifest_file_with_models, test_dag
 
 
 def test_configuration():
@@ -15,18 +15,31 @@ def test_configuration():
     run_task = tasks.get_task("model.dbt_test.dim_users").run_airflow_task
     assert run_task.namespace == "apache-airflow"
     assert run_task.image == "123.gcr/dbt-platform-poc:123"
-    assert run_task.node_selector == {"group": "data-processing"}
-    assert run_task.tolerations[0].key == "group"
-    assert run_task.tolerations[0].operator == "Equal"
-    assert run_task.tolerations[0].value == "data-processing"
-    assert run_task.tolerations[0].effect == "NoSchedule"
+
+    if IS_FIRST_AIRFLOW_VERSION:
+        assert run_task.node_selectors == {"group": "data-processing"}
+        assert run_task.tolerations[0]["key"] == "group"
+        assert run_task.tolerations[0]["operator"] == "Equal"
+        assert run_task.tolerations[0]["value"] == "data-processing"
+        assert run_task.tolerations[0]["effect"] == "NoSchedule"
+        assert run_task.k8s_resources[0].limit_memory == "2048M"
+        assert run_task.k8s_resources[0].limit_cpu == "2"
+        assert run_task.k8s_resources[0].request_memory == "1024M"
+        assert run_task.k8s_resources[0].request_cpu == "1"
+    else:
+        assert run_task.node_selector == {"group": "data-processing"}
+        assert run_task.tolerations[0].key == "group"
+        assert run_task.tolerations[0].operator == "Equal"
+        assert run_task.tolerations[0].value == "data-processing"
+        assert run_task.tolerations[0].effect == "NoSchedule"
+        assert run_task.k8s_resources.limits == {"memory": "2048M", "cpu": "2"}
+        assert run_task.k8s_resources.requests == {"memory": "1024M", "cpu": "1"}
+
     assert run_task.labels == {"runner": "airflow"}
     assert run_task.secrets == [
         Secret("env", "test", "snowflake-access-user-key", None),
         Secret("volume", "/var", "snowflake-access-user-key", None),
     ]
-    assert run_task.k8s_resources.limits == {"memory": "2048M", "cpu": "2"}
-    assert run_task.k8s_resources.requests == {"memory": "1024M", "cpu": "1"}
     assert run_task.is_delete_operator_pod
     assert "--project-dir /dbt" in run_task.arguments[0]
     assert "--profiles-dir /root/.dbt" in run_task.arguments[0]

--- a/tests/test_dag_factory.py
+++ b/tests/test_dag_factory.py
@@ -3,6 +3,8 @@ from os import path
 
 from dbt_airflow_manifest_parser.airflow_dag_factory import AirflowDagFactory
 
+from .utils import IS_FIRST_AIRFLOW_VERSION
+
 
 def test_dag_factory():
     # given
@@ -27,3 +29,33 @@ def test_dag_factory():
         "retry_delay": 300,
     }
     assert len(dag.tasks) == 4
+
+
+def test_task_group_dag_factory():
+    if IS_FIRST_AIRFLOW_VERSION:  # You cannot use TaskGroup in Airflow 1 anyway
+        return True
+
+    # given
+    factory = AirflowDagFactory(path.dirname(path.abspath(__file__)), "task_group")
+
+    # when
+    dag = factory.create()
+
+    # then
+    assert len(dag.tasks) == 10
+    assert len(dag.task_group.children) == 6
+
+
+def test_no_task_group_dag_factory():
+    if IS_FIRST_AIRFLOW_VERSION:  # You cannot use TaskGroup in Airflow 1 anyway
+        return True
+
+    # given
+    factory = AirflowDagFactory(path.dirname(path.abspath(__file__)), "no_task_group")
+
+    # when
+    dag = factory.create()
+
+    # then
+    assert len(dag.tasks) == 10
+    assert len(dag.task_group.children) == 10

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,4 +1,9 @@
-from .utils import builder_factory, manifest_file_with_models, test_dag
+from .utils import (
+    builder_factory,
+    manifest_file_with_models,
+    task_group_prefix_builder,
+    test_dag,
+)
 
 
 def test_run_test_dependency():
@@ -11,11 +16,11 @@ def test_run_test_dependency():
 
     # then
     assert (
-        "model1_test"
+        task_group_prefix_builder("model1_test")
         in tasks.get_task("model.dbt_test.model1").run_airflow_task.downstream_task_ids
     )
     assert (
-        "model1_run"
+        task_group_prefix_builder("model1_run")
         in tasks.get_task("model.dbt_test.model1").test_airflow_task.upstream_task_ids
     )
 
@@ -35,12 +40,13 @@ def test_dependency():
 
     # then
     assert tasks.length() == 2
+
     assert (
-        "model1_test"
+        task_group_prefix_builder("model1_test")
         in tasks.get_task("model.dbt_test.model2").run_airflow_task.upstream_task_ids
     )
     assert (
-        "model2_run"
+        task_group_prefix_builder("model2_run")
         in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
     )
 
@@ -63,30 +69,30 @@ def test_more_complex_dependencies():
     # then
     assert tasks.length() == 4
     assert (
-        "model1_test"
+        task_group_prefix_builder("model1_test")
         in tasks.get_task("model.dbt_test.model2").run_airflow_task.upstream_task_ids
     )
     assert (
-        "model1_test"
+        task_group_prefix_builder("model1_test")
         in tasks.get_task("model.dbt_test.model3").run_airflow_task.upstream_task_ids
     )
     assert (
-        "model2_run"
+        task_group_prefix_builder("model2_run")
         in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
     )
     assert (
-        "model3_run"
+        task_group_prefix_builder("model3_run")
         in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
     )
     assert (
-        "model1_test"
+        task_group_prefix_builder("model1_test")
         in tasks.get_task("model.dbt_test.model3").run_airflow_task.upstream_task_ids
     )
     assert (
-        "model2_test"
+        task_group_prefix_builder("model2_test")
         in tasks.get_task("model.dbt_test.model3").run_airflow_task.upstream_task_ids
     )
     assert (
-        "model4_run"
+        task_group_prefix_builder("model4_run")
         in tasks.get_task("model.dbt_test.model3").test_airflow_task.downstream_task_ids
     )

--- a/tests/test_eadges.py
+++ b/tests/test_eadges.py
@@ -1,4 +1,9 @@
-from .utils import builder_factory, manifest_file_with_models, test_dag
+from .utils import (
+    builder_factory,
+    manifest_file_with_models,
+    task_group_prefix_builder,
+    test_dag,
+)
 
 
 def test_starting_tasks():
@@ -21,9 +26,9 @@ def test_starting_tasks():
     starting_tasks_names = [
         task.run_airflow_task.task_id for task in tasks.get_starting_tasks()
     ]
-    assert "model1_run" in starting_tasks_names
-    assert "model2_run" in starting_tasks_names
-    assert "model5_run" in starting_tasks_names
+    assert task_group_prefix_builder("model1_run") in starting_tasks_names
+    assert task_group_prefix_builder("model2_run") in starting_tasks_names
+    assert task_group_prefix_builder("model5_run") in starting_tasks_names
 
 
 def test_ending_tasks():
@@ -46,5 +51,5 @@ def test_ending_tasks():
     ending_tasks_names = [
         task.test_airflow_task.task_id for task in tasks.get_ending_tasks()
     ]
-    assert "model4_test" in ending_tasks_names
-    assert "model5_test" in ending_tasks_names
+    assert task_group_prefix_builder("model4_test") in ending_tasks_names
+    assert task_group_prefix_builder("model5_test") in ending_tasks_names

--- a/tests/test_task_group.py
+++ b/tests/test_task_group.py
@@ -1,0 +1,130 @@
+from .utils import (
+    builder_factory,
+    manifest_file_with_models,
+    task_group_prefix_builder,
+    test_dag,
+)
+
+
+def test_task_group():
+    # given
+    manifest_path = manifest_file_with_models(
+        {
+            "model.dbt_test.model1": [],
+            "model.dbt_test.model2": ["model.dbt_test.model1"],
+            "model.dbt_test.model3": ["model.dbt_test.model1"],
+            "model.dbt_test.model4": ["model.dbt_test.model2", "model.dbt_test.model3"],
+        }
+    )
+
+    # when
+    with test_dag():
+        tasks = builder_factory().create().parse_manifest_into_tasks(manifest_path)
+
+    # then
+    assert (
+        task_group_prefix_builder("model1_test")
+        in tasks.get_task("model.dbt_test.model1").run_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model1_run")
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.upstream_task_ids
+    )
+
+    assert (
+        task_group_prefix_builder("model1_test")
+        in tasks.get_task("model.dbt_test.model2").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model2_run")
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
+    )
+
+    assert (
+        task_group_prefix_builder("model1_test")
+        in tasks.get_task("model.dbt_test.model3").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model3_run")
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
+    )
+
+    assert (
+        task_group_prefix_builder("model2_test")
+        in tasks.get_task("model.dbt_test.model4").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model3_test")
+        in tasks.get_task("model.dbt_test.model4").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model4_run")
+        in tasks.get_task("model.dbt_test.model2").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model4_run")
+        in tasks.get_task("model.dbt_test.model3").test_airflow_task.downstream_task_ids
+    )
+
+
+def test_no_task_group():
+    # given
+    manifest_path = manifest_file_with_models(
+        {
+            "model.dbt_test.model1": [],
+            "model.dbt_test.model2": ["model.dbt_test.model1"],
+            "model.dbt_test.model3": ["model.dbt_test.model1"],
+            "model.dbt_test.model4": ["model.dbt_test.model2", "model.dbt_test.model3"],
+        }
+    )
+
+    # when
+    with test_dag():
+        tasks = (
+            builder_factory().create().parse_manifest_into_tasks(manifest_path, False)
+        )
+
+    # then
+    assert (
+        "model1_test"
+        in tasks.get_task("model.dbt_test.model1").run_airflow_task.downstream_task_ids
+    )
+    assert (
+        "model1_run"
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.upstream_task_ids
+    )
+
+    assert (
+        "model1_test"
+        in tasks.get_task("model.dbt_test.model2").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        "model2_run"
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
+    )
+
+    assert (
+        "model1_test"
+        in tasks.get_task("model.dbt_test.model3").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        "model3_run"
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
+    )
+
+    assert (
+        "model2_test"
+        in tasks.get_task("model.dbt_test.model4").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        "model3_test"
+        in tasks.get_task("model.dbt_test.model4").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        "model4_run"
+        in tasks.get_task("model.dbt_test.model2").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        "model4_run"
+        in tasks.get_task("model.dbt_test.model3").test_airflow_task.downstream_task_ids
+    )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,4 +1,9 @@
-from .utils import builder_factory, manifest_file_with_models, test_dag
+from .utils import (
+    builder_factory,
+    manifest_file_with_models,
+    task_group_prefix_builder,
+    test_dag,
+)
 
 
 def test_get_dag():
@@ -30,7 +35,7 @@ def test_run_task():
     assert "set -e; dbt --no-write-json run " in run_task.arguments[0]
     assert "--models dim_users" in run_task.arguments[0]
     assert run_task.name == "dim-users-run"
-    assert run_task.task_id == "dim_users_run"
+    assert run_task.task_id == task_group_prefix_builder("dim_users_run")
 
 
 def test_test_task():
@@ -47,4 +52,4 @@ def test_test_task():
     assert "set -e; dbt --no-write-json test " in test_task.arguments[0]
     assert "--models dim_users" in test_task.arguments[0]
     assert test_task.name == "dim-users-test"
-    assert test_task.task_id == "dim_users_test"
+    assert test_task.task_id == task_group_prefix_builder("dim_users_test")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,3 +32,9 @@ def test_dag():
 
 
 IS_FIRST_AIRFLOW_VERSION = airflow.__version__.startswith("1.")
+
+
+def task_group_prefix_builder(task_id: str):
+    task_model_id = "_".join(task_id.split("_")[:-1])
+    prefix = (task_model_id + ".") if not IS_FIRST_AIRFLOW_VERSION else ""
+    return prefix + task_id

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from datetime import datetime
 
+import airflow
 from airflow import DAG
 
 from dbt_airflow_manifest_parser.builder_factory import DbtAirflowTasksBuilderFactory
@@ -28,3 +29,6 @@ def builder_factory():
 
 def test_dag():
     return DAG("test", default_args={"start_date": datetime(2021, 10, 13)})
+
+
+IS_FIRST_AIRFLOW_VERSION = airflow.__version__.startswith("1.")


### PR DESCRIPTION
## Allow usage of `TaskGroup` in Airflow 2

Also, fixes tests incompatible with Airflow 1

---
Keep in mind:
- [ ] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 