### PR TITLE
Make constructors parsed from configs transparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changed
+- Add `**kwargs` argument to `DbtExecutionEnvironmentParameters` and `KubernetesExecutionParameters` constructors,
+making them ignore additional arguments, if provided.
+
 ## [0.13.0] - 2021-11-17
 
 ## [0.12.0] - 2021-11-17

--- a/dbt_airflow_manifest_parser/dbt_parameters.py
+++ b/dbt_airflow_manifest_parser/dbt_parameters.py
@@ -4,6 +4,7 @@ class DbtExecutionEnvironmentParameters:
         target: str,
         project_dir_path: str = "/dbt",
         profile_dir_path: str = "/root/.dbt",
+        **kwargs,
     ):
         self.target = target
         self.project_dir_path = project_dir_path

--- a/dbt_airflow_manifest_parser/k8s_parameters.py
+++ b/dbt_airflow_manifest_parser/k8s_parameters.py
@@ -22,6 +22,7 @@ class KubernetesExecutionParameters:
         annotations: dict = None,
         secrets: List[Secret] = None,
         is_delete_operator_pod: bool = True,
+        **kwargs,
     ):
         self.namespace = namespace
         self.image = image

--- a/tests/config/base/dbt.yml
+++ b/tests/config/base/dbt.yml
@@ -1,3 +1,4 @@
 target: local
+target_type: bigquery
 project_dir_path: /dbt
 profile_dir_path: /root/.dbt


### PR DESCRIPTION
Constructors of `DbtExecutionEnvironmentParameters` and `KubernetesExecutionParameters` are getting called with parameters extracted from specific config files (e.g., `config/base/dbt.yml`). If one adds one's own fields to those config files, those fields will be handed over to constructor making it fail. This commit fixes such behaviour by adding `**kwargs` argument to those two constructors, making them ignore additional arguments if provided.

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates 